### PR TITLE
feat(radar): crear WordPress por posición desde cada radar

### DIFF
--- a/src/services/list/list.ts
+++ b/src/services/list/list.ts
@@ -79,8 +79,10 @@ export interface WeeklyWpPostRecord {
   wpPostUrl: string;
 }
 
-export async function createWpPosts(id: string): Promise<CreateWpPostsResponse> {
-  const response = await api.post<CreateWpPostsResponse>(`/lists/${id}/wp-posts`);
+export async function createWpPosts(id: string, position?: number): Promise<CreateWpPostsResponse> {
+  const response = await api.post<CreateWpPostsResponse>(`/lists/${id}/wp-posts`, null, {
+    params: position ? { position } : undefined,
+  });
   return response.data;
 }
 

--- a/src/views/discos/RadarDetalle.vue
+++ b/src/views/discos/RadarDetalle.vue
@@ -46,14 +46,6 @@
 
             <!-- Controles -->
             <div class="flex flex-wrap items-center gap-2 w-full md:w-auto">
-              <!-- WordPress -->
-              <button @click="publishToWordPress" :disabled="publishingWp"
-                class="flex items-center gap-2 px-3 py-2 bg-orange-500 hover:bg-orange-600 disabled:opacity-50 text-white text-sm font-semibold rounded-xl shadow-sm transition-colors">
-                <i class="fab fa-wordpress"></i>
-                <span class="hidden sm:inline">{{ publishingWp ? 'Publicando...' : 'Publicar en WP' }}</span>
-                <span class="sm:hidden">{{ publishingWp ? '...' : 'WP' }}</span>
-              </button>
-
               <!-- Status -->
               <div class="relative">
                 <select
@@ -106,7 +98,8 @@
             <h2 class="text-base font-bold text-gray-900 dark:text-white">Asignaciones</h2>
           </div>
           <div class="p-4 md:p-5">
-            <AsignationList :type="list.type" :wp-weekly-posts="list.wpWeeklyPosts" />
+            <AsignationList :type="list.type" :list-id="list.id" :wp-weekly-posts="list.wpWeeklyPosts"
+              @wp-published="mergeWeeklyWpPosts" />
           </div>
         </div>
 
@@ -136,9 +129,8 @@
 <script setup lang="ts">
 import { ref, onMounted, computed } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
-import { getListDetails, updateList, createWpPosts } from '@services/list/list';
+import { getListDetails, updateList } from '@services/list/list';
 import SwalService from '@services/swal/SwalService';
-import Swal from 'sweetalert2';
 import { useAsignationStore } from '@stores/asignation/asignation';
 import { useUserStore } from '@stores/user/users';
 import DiscsByDate from '../list/components/DiscByDate.vue';
@@ -151,7 +143,6 @@ const userStore = useUserStore();
 
 const list = ref<any>(null);
 const loading = ref(true);
-const publishingWp = ref(false);
 
 function formatDateForInput(dateString: string) {
   if (!dateString) return '';
@@ -232,62 +223,17 @@ async function updateField(field: string, value: any) {
   }
 }
 
-async function publishToWordPress() {
+function mergeWeeklyWpPosts(posts: any[]) {
   if (!list.value) return;
-  publishingWp.value = true;
-  try {
-    const result = await createWpPosts(list.value.id);
-
-    const existingWeeklyPosts = Array.isArray(list.value.wpWeeklyPosts) ? list.value.wpWeeklyPosts : [];
-    const mergedWeeklyPosts = [...existingWeeklyPosts];
-    for (const p of result.posts) {
-      const record = { position: p.position, wpPostId: p.wpPostId, wpPostUrl: p.link };
-      const idx = mergedWeeklyPosts.findIndex((e: any) => e.position === p.position);
-      if (idx !== -1) mergedWeeklyPosts[idx] = record;
-      else mergedWeeklyPosts.push(record);
-    }
-    list.value.wpWeeklyPosts = mergedWeeklyPosts;
-
-    const postsHtml = result.posts
-      .map(p => {
-        const linkHtml = `<a href="${p.link}" target="_blank" class="text-blue-600 underline">${p.title}</a>`;
-
-        const changes: string[] = [];
-        if (p.added) changes.push(`${p.added} añadido${p.added === 1 ? '' : 's'}`);
-        if (p.updated) changes.push(`${p.updated} actualizado${p.updated === 1 ? '' : 's'}`);
-        if (p.removed) changes.push(`${p.removed} eliminado${p.removed === 1 ? '' : 's'}`);
-
-        let icon = '✅';
-        let statusText = 'Creado';
-        if (p.adopted) {
-          icon = 'ℹ️';
-          statusText = 'Vinculado a un post existente sin trackear';
-        } else if (p.warning) {
-          icon = '⚠️';
-          statusText = changes.length ? `Actualizado (${changes.join(', ')})` : 'Aviso al actualizar';
-        } else if (changes.length) {
-          statusText = `Actualizado (${changes.join(', ')})`;
-        }
-
-        return `<li class="mb-2">
-          <div>${icon} Posición ${p.position} — ${statusText}</div>
-          <div>${linkHtml}</div>
-          ${p.warning ? `<div class="text-amber-600 text-xs mt-1">${p.warning}</div>` : ''}
-        </li>`;
-      })
-      .join('');
-
-    const hasWarning = result.posts.some(p => p.warning);
-    Swal.fire({
-      icon: hasWarning ? 'warning' : 'success',
-      title: 'Resultado de publicación en WordPress',
-      html: `<ul class="text-left text-sm mt-2">${postsHtml}</ul>`,
-    });
-  } catch (error: any) {
-    SwalService.error(error.response?.data?.message || 'Error al publicar en WordPress');
-  } finally {
-    publishingWp.value = false;
+  const existingWeeklyPosts = Array.isArray(list.value.wpWeeklyPosts) ? list.value.wpWeeklyPosts : [];
+  const mergedWeeklyPosts = [...existingWeeklyPosts];
+  for (const p of posts) {
+    const record = { position: p.position, wpPostId: p.wpPostId, wpPostUrl: p.link };
+    const idx = mergedWeeklyPosts.findIndex((e: any) => e.position === p.position);
+    if (idx !== -1) mergedWeeklyPosts[idx] = record;
+    else mergedWeeklyPosts.push(record);
   }
+  list.value.wpWeeklyPosts = mergedWeeklyPosts;
 }
 
 onMounted(() => {

--- a/src/views/list/components/AsignationList.vue
+++ b/src/views/list/components/AsignationList.vue
@@ -35,6 +35,11 @@
                 <i class="fab fa-wordpress"></i>
                 <span>Borrador</span>
               </a>
+              <button @click="publishRadarToWordPress(group)" :disabled="publishingRadar[group]"
+                :title="(getWeeklyWpPost(group) ? 'Actualizar' : 'Crear') + ' WordPress del Radar ' + group"
+                class="w-6 h-6 flex items-center justify-center rounded-md bg-orange-50 dark:bg-orange-900/20 text-orange-500 hover:bg-orange-100 dark:hover:bg-orange-900/30 disabled:opacity-50 transition-colors">
+                <i :class="publishingRadar[group] ? 'fa-solid fa-spinner fa-spin' : 'fab fa-wordpress'" class="text-xs"></i>
+              </button>
               <span class="text-[10px] font-bold px-2 py-0.5 rounded-full border transition-colors shadow-sm"
                 :class="(groupedWeekAsignations[group]?.length || 0) >= 4
                   ? 'bg-red-50 dark:bg-red-900/20 text-red-600 dark:text-red-400 border-red-100 dark:border-red-900/30'
@@ -375,22 +380,26 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, ref, watch, computed, nextTick } from "vue";
+import { defineComponent, ref, reactive, watch, computed, nextTick } from "vue";
 import { useAsignationStore } from "@stores/asignation/asignation";
 import { useUserStore } from "@stores/user/users";
 import SpotifyArtistButton from "@components/SpotifyArtistButton.vue";
 import DiscDescriptionModal from "./DiscDescriptionModal.vue";
 import SwalService from "@services/swal/SwalService";
+import { createWpPosts } from "@services/list/list";
+import Swal from "sweetalert2";
 import CircleFlags from "vue-circle-flags";
 
 export default defineComponent({
   name: "AsignationList",
   props: {
     type: { type: String, required: true },
+    listId: { type: String, required: true },
     wpWeeklyPosts: { type: Array as () => any[], default: () => [] },
   },
+  emits: ["wp-published"],
   components: { SpotifyArtistButton, DiscDescriptionModal },
-  setup(props) {
+  setup(props, { emit }) {
     const asignationStore = useAsignationStore();
     const userStore = useUserStore();
     const asignations = ref<any[]>([]);
@@ -566,6 +575,57 @@ export default defineComponent({
       return (props.wpWeeklyPosts || []).find((p: any) => p.position === group) || null;
     };
 
+    const publishingRadar = reactive<Record<number, boolean>>({});
+
+    const publishRadarToWordPress = async (group: number) => {
+      if (publishingRadar[group]) return;
+      publishingRadar[group] = true;
+      try {
+        const result = await createWpPosts(props.listId, group);
+        emit("wp-published", result.posts);
+
+        const postsHtml = result.posts
+          .map((p: any) => {
+            const linkHtml = `<a href="${p.link}" target="_blank" class="text-blue-600 underline">${p.title}</a>`;
+
+            const changes: string[] = [];
+            if (p.added) changes.push(`${p.added} añadido${p.added === 1 ? '' : 's'}`);
+            if (p.updated) changes.push(`${p.updated} actualizado${p.updated === 1 ? '' : 's'}`);
+            if (p.removed) changes.push(`${p.removed} eliminado${p.removed === 1 ? '' : 's'}`);
+
+            let icon = '✅';
+            let statusText = 'Creado';
+            if (p.adopted) {
+              icon = 'ℹ️';
+              statusText = 'Vinculado a un post existente sin trackear';
+            } else if (p.warning) {
+              icon = '⚠️';
+              statusText = changes.length ? `Actualizado (${changes.join(', ')})` : 'Aviso al actualizar';
+            } else if (changes.length) {
+              statusText = `Actualizado (${changes.join(', ')})`;
+            }
+
+            return `<li class="mb-2">
+              <div>${icon} ${statusText}</div>
+              <div>${linkHtml}</div>
+              ${p.warning ? `<div class="text-amber-600 text-xs mt-1">${p.warning}</div>` : ''}
+            </li>`;
+          })
+          .join('');
+
+        const hasWarning = result.posts.some((p: any) => p.warning);
+        Swal.fire({
+          icon: hasWarning ? 'warning' : 'success',
+          title: `Radar ${group}`,
+          html: `<ul class="text-left text-sm mt-2">${postsHtml}</ul>`,
+        });
+      } catch (error: any) {
+        SwalService.error(error.response?.data?.message || `Error al publicar el Radar ${group} en WordPress`);
+      } finally {
+        publishingRadar[group] = false;
+      }
+    };
+
     return {
       asignations, isWeek, unassignedWeekAsignations, groupedWeekAsignations,
       availablePositions, availablePositionsCount, remove, toggleDone,
@@ -574,7 +634,7 @@ export default defineComponent({
       users, editingUserAsignationId, startEditingUser, changeUser,
       moveTo, getDiscCountry,
       editingAsignation, savingDescription, openDescriptionModal, handleSaveDescription,
-      getWeeklyWpPost,
+      getWeeklyWpPost, publishingRadar, publishRadarToWordPress,
     };
   },
 });


### PR DESCRIPTION
Sustituye el botón global "Publicar en WP" por un botón individual en cada tarjeta de radar, que llama a POST /lists/:id/wp-posts con el parámetro position para crear/actualizar solo esa página.