### PR TITLE
fix(api): evitar body "null" en peticiones POST sin payload

### DIFF
--- a/src/services/lastfm/lastfm.ts
+++ b/src/services/lastfm/lastfm.ts
@@ -27,7 +27,7 @@ export async function getArtistInfo(artistName: string): Promise<LastFmArtist> {
 }
 
 export async function fillImages(month: number, year: number, week: number): Promise<FillImagesResponse> {
-  const response = await api.post("/lastfm/fill-images", null, {
+  const response = await api.post("/lastfm/fill-images", {}, {
     params: { month, year, week },
   });
   return response.data;

--- a/src/services/list/list.ts
+++ b/src/services/list/list.ts
@@ -80,7 +80,7 @@ export interface WeeklyWpPostRecord {
 }
 
 export async function createWpPosts(id: string, position?: number): Promise<CreateWpPostsResponse> {
-  const response = await api.post<CreateWpPostsResponse>(`/lists/${id}/wp-posts`, null, {
+  const response = await api.post<CreateWpPostsResponse>(`/lists/${id}/wp-posts`, {}, {
     params: position ? { position } : undefined,
   });
   return response.data;


### PR DESCRIPTION
axios serializa el segundo argumento null como el string literal "null" en vez de dejar el body vacío, ya que la instancia api fija Content-Type: application/json por defecto. Con un parser JSON en modo estricto en el backend (solo acepta {...} o [...]), esto provoca un 400 antes de llegar al controlador, sin logs y en 1-3ms.

Se sustituye null por {} (que sí serializa a JSON válido) en createWpPosts (list.ts) y fillImages (lastfm.ts), únicos casos con este patrón en el repo.